### PR TITLE
enable manual dispatching of publish job

### DIFF
--- a/.github/workflows/build_backend.yml
+++ b/.github/workflows/build_backend.yml
@@ -1,12 +1,14 @@
 name: Build and Test Backend
 
-on: push
+on:
+  push:
+  workflow_dispatch:
 
 jobs:
   build:
     name: Build Backend
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main'
+    if: github.ref != 'refs/heads/main' && github.event_name != 'workflow_dispatch'
 
     steps:
       - name: Check out repository
@@ -19,7 +21,7 @@ jobs:
   publish-build:
     name: Publish Backend
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
enables manual dispatching of the publish-build job to deploy on the OTC server. A temporary workaround as long as we don't have dev-spaces.
If you run the job manually please check the `pre-prod-deployment` channel on the discord server if anyone else has deployed something right know.